### PR TITLE
Create master branch at HEAD for repo being tested

### DIFF
--- a/build_pull_request.py
+++ b/build_pull_request.py
@@ -114,6 +114,7 @@ def main():
         execute("%s remote set-url origin %s" %
                 (git_exe, os.environ['GIT_URL']))
         execute("%s status" % git_exe)
+        execute("%s checkout -b master" % git_exe)
 
         print_heading("Start the build...")
 


### PR DESCRIPTION
For the repo which we are testing the build, we currently clone but do
not create a branch. This means that when building the build system
component `planex-pin update` fails, complaining that the master branch
does not exist.

To solve this, create a new master branch at the current HEAD.
